### PR TITLE
Enable -Wall -Wextra as errors and fix compile warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Source tree: libraries, servers, and apps.
 
-# Treat warnings as errors for project code (vendored targets under lib/ opt out).
-add_compile_options(-Werror)
+# Enable common warnings and treat them as errors for project code.
+# Vendored targets (libsodium, CLI11, httplib) opt out via -Wno-error.
+if(MSVC)
+  add_compile_options(/W4 /WX)
+else()
+  add_compile_options(-Wall -Wextra -Werror)
+endif()
 
 add_subdirectory(lib)
 add_subdirectory(consensus)

--- a/src/chain/Chain.cpp
+++ b/src/chain/Chain.cpp
@@ -199,7 +199,7 @@ Chain::createRenewalTx(uint64_t accountId) const {
       accountId != AccountBuffer::ID_FEE) {
     auto balance =
         txContext_.bank.getBalance(accountId, AccountBuffer::ID_GENESIS);
-    if (balance < minimumFee) {
+    if (balance < static_cast<int64_t>(minimumFee)) {
       // Insufficient balance for renewal, terminate account with whatever
       // balance remains. Fee is 0 here; all remaining balances are transferred
       // to recycle account. Never terminate fee account (it pays fee to self).
@@ -249,7 +249,7 @@ Chain::calculateMaxBlockIdForRenewal(uint64_t atBlockId) const {
 }
 
 Chain::Roe<std::vector<Ledger::Record>>
-Chain::collectRenewals(uint64_t slot) const {
+Chain::collectRenewals(uint64_t /*slot*/) const {
   std::vector<Ledger::Record> renewals;
   const uint64_t nextBlockId = txContext_.ledger.getNextBlockId();
 

--- a/src/chain/NewUserTxHandler.cpp
+++ b/src/chain/NewUserTxHandler.cpp
@@ -198,7 +198,7 @@ chain_tx::Roe<void> NewUserTxHandler::applyNewUser(
         chain_err::E_TX_VALIDATION,
         "User account must have balance in ID_GENESIS token");
   }
-  if (it->second != tx.amount) {
+  if (it->second != static_cast<int64_t>(tx.amount)) {
     return chain_tx::TxError(
         chain_err::E_TX_VALIDATION,
         "User account must have balance in ID_GENESIS token: " +

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -233,7 +233,6 @@ private:
   Roe<std::string> sendRequest(uint32_t type, const std::string &payload,
                                std::chrono::milliseconds timeout = TIMEOUT_FAST);
 
-  bool connected_{false};
   network::IpEndpoint endpoint_;
   network::FetchClient fetchClient_;
 };

--- a/src/consensus/SlotLeaderSelection.cpp
+++ b/src/consensus/SlotLeaderSelection.cpp
@@ -31,7 +31,7 @@ VRF::Roe<VRF::VRFOutput> VRF::evaluate(const std::string &seed, uint64_t slot,
   return VRFOutput(value, proof);
 }
 
-VRF::Roe<bool> VRF::verify(const std::string &output, const std::string &proof,
+VRF::Roe<bool> VRF::verify(const std::string & /*output*/, const std::string &proof,
                            const std::string &seed, uint64_t slot,
                            const std::string &publicKey) const {
 

--- a/src/consensus/test/test_ouroboros_epoch.cpp
+++ b/src/consensus/test/test_ouroboros_epoch.cpp
@@ -207,7 +207,6 @@ TEST_F(SlotTimerTest, ValidatesTimeInSlot) {
 }
 
 TEST_F(SlotTimerTest, CalculatesTimeUntilSlot) {
-    int64_t currentTime = timer->getCurrentTime();
     uint64_t currentSlot = timer->getCurrentSlot(genesisTime);
     uint64_t futureSlot = currentSlot + 10;
     

--- a/src/ledger/test/test_dirdirstore.cpp
+++ b/src/ledger/test/test_dirdirstore.cpp
@@ -783,15 +783,12 @@ TEST_F(DirDirStoreTest, SiblingsHaveSameLevel) {
     // Fill up root level to trigger creation of multiple FileDirStore siblings
     std::string largeData(200 * 1024, 'X');
     
-    size_t blocksAdded = 0;
     for (size_t i = 0; i < 100; i++) {
         if (!dirDirStore.canFit(largeData.size())) {
             break;
         }
         auto result = dirDirStore.appendBlock(largeData);
-        if (result.isOk()) {
-            blocksAdded++;
-        } else {
+        if (!result.isOk()) {
             break;
         }
     }

--- a/src/ledger/test/test_ledger.cpp
+++ b/src/ledger/test/test_ledger.cpp
@@ -31,7 +31,7 @@ protected:
     }
   }
 
-  Ledger::ChainNode createTestBlock(uint64_t id, const std::string& data) {
+  Ledger::ChainNode createTestBlock(uint64_t id, const std::string& /*data*/) {
     Ledger::ChainNode block;
     block.block.index = id;
     block.block.previousHash = "prev_hash_" + std::to_string(id);

--- a/src/lib/cli/CMakeLists.txt
+++ b/src/lib/cli/CMakeLists.txt
@@ -6,7 +6,14 @@ add_library(CLI11::CLI11 ALIAS CLI11)
 
 target_compile_definitions(CLI11 PUBLIC CLI11_COMPILE)
 
-target_include_directories(CLI11 PUBLIC
+target_include_directories(CLI11 SYSTEM PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Upstream warnings must not fail our -Werror builds.
+if(MSVC)
+  target_compile_options(CLI11 PRIVATE /W0 /WX-)
+else()
+  target_compile_options(CLI11 PRIVATE -Wno-error -w)
+endif()

--- a/src/lib/common/Logger.cpp
+++ b/src/lib/common/Logger.cpp
@@ -33,7 +33,7 @@ static std::string getCurrentTimestamp() {
 }
 
 // ConsoleHandler implementation
-void ConsoleHandler::emit(Level level, const std::string &loggerName,
+void ConsoleHandler::emit(Level level, const std::string & /*loggerName*/,
                           const std::string &message) {
   if (level < level_) {
     return;
@@ -55,7 +55,7 @@ FileHandler::~FileHandler() {
   }
 }
 
-void FileHandler::emit(Level level, const std::string &loggerName,
+void FileHandler::emit(Level level, const std::string & /*loggerName*/,
                        const std::string &message) {
   if (level < level_) {
     return;
@@ -277,12 +277,12 @@ static std::shared_ptr<LoggerNode> g_spRoot = initRootLogger();
 // ========== Logger Implementation ==========
 
 Logger::Logger(std::shared_ptr<LoggerNode> node)
-    : spNode_(std::move(node)),
-      debug(this, Level::DEBUG),
+    : debug(this, Level::DEBUG),
       info(this, Level::INFO),
       warning(this, Level::WARNING),
       error(this, Level::ERROR),
-      critical(this, Level::CRITICAL) {
+      critical(this, Level::CRITICAL),
+      spNode_(std::move(node)) {
 }
 
 void Logger::redirectTo(const std::string &targetLoggerName) {

--- a/src/lib/http/CMakeLists.txt
+++ b/src/lib/http/CMakeLists.txt
@@ -1,4 +1,12 @@
 # cpp-httplib library (header + implementation)
 add_library(pp_http STATIC httplib_core.cc httplib_ssl.cc httplib_ws.cc)
 
-target_include_directories(pp_http PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# SYSTEM so httplib.h does not trigger -Werror in dependents.
+target_include_directories(pp_http SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Upstream warnings must not fail our -Werror builds.
+if(MSVC)
+  target_compile_options(pp_http PRIVATE /W0 /WX-)
+else()
+  target_compile_options(pp_http PRIVATE -Wno-error -w)
+endif()

--- a/src/lib/json/CMakeLists.txt
+++ b/src/lib/json/CMakeLists.txt
@@ -5,7 +5,8 @@ cmake_minimum_required(VERSION 3.15)
 add_library(nlohmann_json INTERFACE)
 add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
 
-target_include_directories(nlohmann_json INTERFACE
+# SYSTEM so nlohmann headers do not trigger -Werror in dependents.
+target_include_directories(nlohmann_json SYSTEM INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/lib/sodium/CMakeLists.txt
+++ b/src/lib/sodium/CMakeLists.txt
@@ -277,11 +277,13 @@ set_target_properties(${PROJECT_NAME}
 
 # Upstream warnings must not fail our -Werror builds.
 target_compile_options(${PROJECT_NAME} PRIVATE
-    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang>:-Wno-error>
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang>:-Wno-error -w>
+    $<$<COMPILE_LANG_AND_ID:C,MSVC>:/W0 /WX->
 )
 
+# SYSTEM so sodium headers do not trigger -Werror in dependents.
 target_include_directories(${PROJECT_NAME}
-    PUBLIC
+    SYSTEM PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libsodium/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE

--- a/src/network/test/test_fetch.cpp
+++ b/src/network/test/test_fetch.cpp
@@ -53,7 +53,7 @@ TEST_F(FetchServerTest, CreatesSuccessfully) {
 TEST_F(FetchServerTest, StartsAndStops) {
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18880};
-    config.handler = [this](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [this](int fd, const std::string& req, const IpEndpoint& /*endpoint*/) {
         std::string response = "Echo: " + req;
         server->addResponse(fd, response);
     };
@@ -70,7 +70,7 @@ TEST_F(FetchServerTest, StartsAndStops) {
 TEST_F(FetchServerTest, FailsToStartOnSamePortTwice) {
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18881};
-    config.handler = [this](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [this](int fd, const std::string& req, const IpEndpoint& /*endpoint*/) {
         std::string response = "Echo: " + req;
         server->addResponse(fd, response);
     };
@@ -81,7 +81,7 @@ TEST_F(FetchServerTest, FailsToStartOnSamePortTwice) {
     FetchServer server2;
     FetchServer::Config config2;
     config2.endpoint = {"127.0.0.1", 18881};
-    config2.handler = [](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config2.handler = [](int /*fd*/, const std::string& /*req*/, const IpEndpoint& /*endpoint*/) {
         // This server won't start, so handler won't be called
     };
     auto started2 = server2.start(config2);
@@ -115,7 +115,7 @@ TEST_F(FetchIntegrationTest, ClientServerCommunication) {
     // Start server
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18882};
-    config.handler = [this](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [this](int fd, const std::string& req, const IpEndpoint& /*endpoint*/) {
         std::string response = "Echo: " + req;
         server->addResponse(fd, response);
     };
@@ -138,7 +138,7 @@ TEST_F(FetchIntegrationTest, MultipleRequests) {
     // Start server
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18883};
-    config.handler = [this](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [this](int fd, const std::string& req, const IpEndpoint& /*endpoint*/) {
         std::string response = "Response: " + req;
         server->addResponse(fd, response);
     };
@@ -162,7 +162,7 @@ TEST_F(FetchIntegrationTest, AsyncFetch) {
     // Start server
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18884};
-    config.handler = [this](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [this](int fd, const std::string& req, const IpEndpoint& /*endpoint*/) {
         std::string response = "Async: " + req;
         server->addResponse(fd, response);
     };
@@ -197,7 +197,7 @@ TEST_F(FetchIntegrationTest, FetchSyncTimesOutWhenServerStalls) {
     // Start a server that accepts connections but never responds
     FetchServer::Config config;
     config.endpoint = {"127.0.0.1", 18885};
-    config.handler = [](int fd, const std::string& req, const IpEndpoint& endpoint) {
+    config.handler = [](int /*fd*/, const std::string& /*req*/, const IpEndpoint& /*endpoint*/) {
         // Intentionally do nothing - simulate a stalled server
     };
     auto started = server->start(config);

--- a/src/server/BeaconServer.cpp
+++ b/src/server/BeaconServer.cpp
@@ -722,12 +722,12 @@ BeaconServer::hRegister(const Client::Request &request) {
 }
 
 BeaconServer::Roe<std::string>
-BeaconServer::hStatus(const Client::Request &request) {
+BeaconServer::hStatus(const Client::Request & /*request*/) {
   return utl::binaryPack(buildStateResponse().ltsToMeta());
 }
 
 BeaconServer::Roe<std::string>
-BeaconServer::hCalibration(const Client::Request &request) {
+BeaconServer::hCalibration(const Client::Request & /*request*/) {
   Client::CalibrationResponse response;
   response.msTimestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
                       std::chrono::system_clock::now().time_since_epoch())
@@ -737,7 +737,7 @@ BeaconServer::hCalibration(const Client::Request &request) {
 }
 
 BeaconServer::Roe<std::string>
-BeaconServer::hMinerList(const Client::Request &request) {
+BeaconServer::hMinerList(const Client::Request & /*request*/) {
   std::vector<pp::common::Meta> list;
   list.reserve(mMiners_.size());
   for (const auto &[id, info] : mMiners_) {

--- a/src/server/MinerServer.cpp
+++ b/src/server/MinerServer.cpp
@@ -768,7 +768,7 @@ MinerServer::hTxAdd(const Client::Request &request) {
 }
 
 MinerServer::Roe<std::string>
-MinerServer::hStatus(const Client::Request &request) {
+MinerServer::hStatus(const Client::Request & /*request*/) {
   Client::MinerStatus status;
 
   status.minerId = config_.minerId;
@@ -792,7 +792,7 @@ MinerServer::hStatus(const Client::Request &request) {
 }
 
 MinerServer::Roe<std::string>
-MinerServer::hCalibration(const Client::Request &request) {
+MinerServer::hCalibration(const Client::Request & /*request*/) {
   if (!miner_.isConfigReady()) {
     return Error(E_REQUEST, "Miner syncing, please retry later");
   }

--- a/src/server/RelayServer.cpp
+++ b/src/server/RelayServer.cpp
@@ -571,12 +571,12 @@ RelayServer::hRegister(const Client::Request &request) {
 }
 
 RelayServer::Roe<std::string>
-RelayServer::hStatus(const Client::Request &request) {
+RelayServer::hStatus(const Client::Request & /*request*/) {
   return utl::binaryPack(buildStateResponse().ltsToMeta());
 }
 
 RelayServer::Roe<std::string>
-RelayServer::hCalibration(const Client::Request &request) {
+RelayServer::hCalibration(const Client::Request & /*request*/) {
   int64_t nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                       std::chrono::system_clock::now().time_since_epoch())
                       .count();
@@ -628,7 +628,7 @@ RelayServer::Roe<int64_t> RelayServer::calibrateTimeToBeacon() {
 }
 
 RelayServer::Roe<std::string>
-RelayServer::hMinerList(const Client::Request &request) {
+RelayServer::hMinerList(const Client::Request & /*request*/) {
   std::vector<pp::common::Meta> list;
   list.reserve(mMiners_.size());
   for (const auto &[id, info] : mMiners_) {

--- a/src/server/Server.h
+++ b/src/server/Server.h
@@ -64,7 +64,7 @@ protected:
   void stopFetchServer();
 
   /** Override to customize FetchServer config (e.g. whitelist) before start. */
-  virtual void customizeFetchServerConfig(network::FetchServer::Config &config) {}
+  virtual void customizeFetchServerConfig(network::FetchServer::Config & /*config*/) {}
 
   void onStop() override;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Project code already had bare `-Werror`, which barely did anything without warning groups enabled. This turns on `-Wall -Wextra -Werror` (and `/W4 /WX` on MSVC) for project sources and cleans up the warnings that then fail the build.

Vendored libraries stay exempt so upstream noise does not break the tree:
- libsodium / CLI11 / httplib compile with `-Wno-error -w`
- nlohmann/json, sodium, CLI11, and httplib headers are marked `SYSTEM`

## Fixes
- Unused parameters / unused private field / unused locals in logger, consensus, client, servers, and tests
- `Logger` constructor member init order (`-Wreorder-ctor`)
- Signed/unsigned comparisons in `Chain` / `NewUserTxHandler` (match existing `static_cast<int64_t>` pattern)

## Verification
- Clang Release build with `-DBUILD_TESTING=ON -DBUILD_HTTP=ON`: clean
- GCC Release build with the same flags: clean
- `ctest`: 346/346 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe6e3-50f9-70ff-9b29-d10e57718c27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe6e3-50f9-70ff-9b29-d10e57718c27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

